### PR TITLE
Clarify run from anywhere, packaging standards, editable install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Based on: [Packaging Your Python Code With pyproject.toml](https://www.youtube.c
 
 Pros:
 
-- Run your CLI script from anywhere using only the script name—no need to navigate to the script directory, enter the script path, or type `python` before the script name
-- Follow Python packaging standards (`pyproject.toml`, editable installs)
-- Avoid rebuilds after changes
-- Integrate easily with IDEs, CI, and deployment tools
+- Run your CLI script from anywhere using only the script name (No script directory navigation, No script path to enter, No `python` before the script name)
+- Follow Python packaging standards (`pyproject.toml` configuration)
+- Avoid reinstall after code changes (editable installs)
+- Integrate easily with IDEs and deployment tools
 
 Cons:
 


### PR DESCRIPTION
# Clarify CLI run explanation and improve packaging detail

This update rewrites the “Pros” section in the README to clarify the benefits of using a CLI script installed via pyproject.toml and editable mode. Specifically:
- Refines the explanation of running the script globally by removing directory navigation, script path, or the python prefix
- Rephrases the packaging standards point for clarity (pyproject.toml configuration)
- Uses clearer terminology: “reinstall after code changes” instead of “rebuilds”